### PR TITLE
Add Oh My Pi as its own agent

### DIFF
--- a/apps/ios/Zeron/Models/HarnessCatalog.swift
+++ b/apps/ios/Zeron/Models/HarnessCatalog.swift
@@ -37,8 +37,11 @@ enum HarnessCatalog {
         "grok": "Grok",
         "hermes": "Hermes",
         "pi": "Pi",
+        "oh-my-pi": "Oh My Pi",
+        "opencode": "OpenCode",
         "cursor": "Cursor",
         "mock": "Mock",
+
     ]
 
     static func label(for harness: String) -> String {

--- a/apps/ios/Zeron/Theme/BrandMarks.swift
+++ b/apps/ios/Zeron/Theme/BrandMarks.swift
@@ -52,7 +52,8 @@ enum BrandMark {
         case "cursor": return .cursor
         case "grok": return .grok
         case "hermes": return .hermes
-        case "pi": return .pi
+        case "pi", "oh-my-pi": return .pi
+
         default: return .claude  // claude-code + mock share the mark, like the desktop
         }
     }

--- a/apps/zeron/src/main.rs
+++ b/apps/zeron/src/main.rs
@@ -237,6 +237,8 @@ fn harness_from_env() -> zeron_engine::HarnessId {
         Ok("grok") => zeron_engine::HarnessId::Grok,
         Ok("hermes") => zeron_engine::HarnessId::Hermes,
         Ok("pi") => zeron_engine::HarnessId::Pi,
+        Ok("oh-my-pi") => zeron_engine::HarnessId::OhMyPi,
+
         _ => zeron_engine::HarnessId::ClaudeCode,
     }
 }

--- a/crates/engine/src/agent_accounts.rs
+++ b/crates/engine/src/agent_accounts.rs
@@ -1383,6 +1383,8 @@ fn harness_slug(harness: HarnessId) -> &'static str {
         HarnessId::Hermes => "hermes",
         HarnessId::Pi => "pi",
         HarnessId::Opencode => "opencode",
+        HarnessId::OhMyPi => "oh-my-pi",
+
         HarnessId::Mock => "mock",
     }
 }

--- a/crates/engine/src/registry.rs
+++ b/crates/engine/src/registry.rs
@@ -477,6 +477,29 @@ pub fn default_registry() -> HarnessRegistry {
         Box::new(|| zeron_harness::AcpHarness::opencode().installed()),
         Box::new(|| Ok(Arc::new(zeron_harness::AcpHarness::opencode()) as Arc<dyn Harness>)),
     );
+    // Oh My Pi over ACP (`omp acp`). Separate product from Pi — do not
+    // share a slot. Same lazy pattern as Hermes.
+    registry.register_lazy(
+        HarnessDescriptor {
+            id: HarnessId::OhMyPi,
+            name: "Oh My Pi".into(),
+            supports_steering: true,
+            steering_mode: SteeringMode::TurnBoundary,
+            reasoning_levels: vec![
+                ReasoningLevel::Minimal,
+                ReasoningLevel::Low,
+                ReasoningLevel::Medium,
+                ReasoningLevel::High,
+                ReasoningLevel::XHigh,
+                ReasoningLevel::Max,
+            ],
+            installed: true,
+            enabled: None,
+        },
+        Box::new(|| zeron_harness::AcpHarness::oh_my_pi().installed()),
+        Box::new(|| Ok(Arc::new(zeron_harness::AcpHarness::oh_my_pi()) as Arc<dyn Harness>)),
+    );
+
     registry
 }
 
@@ -534,7 +557,9 @@ mod tests {
                 HarnessId::Grok,
                 HarnessId::Hermes,
                 HarnessId::Pi,
-                HarnessId::Opencode
+                HarnessId::Opencode,
+                HarnessId::OhMyPi
+
             ]
         );
         assert!(registry.resolve(HarnessId::Mock).is_ok());
@@ -557,7 +582,8 @@ mod tests {
                 ReasoningLevel::High
             ]
         );
-        // Cursor, Hermes and Pi mirror their specs the same way.
+        // Cursor, Hermes, Pi, OpenCode and Oh My Pi mirror their specs the same way.
+
         let cursor = registry.resolve(HarnessId::Cursor).unwrap();
         assert_eq!(cursor.id(), HarnessId::Cursor);
         assert_eq!(cursor.display_name(), "Cursor");
@@ -597,6 +623,22 @@ mod tests {
                 ReasoningLevel::Max
             ]
         );
+        let omp = registry.resolve(HarnessId::OhMyPi).unwrap();
+        assert_eq!(omp.id(), HarnessId::OhMyPi);
+        assert_eq!(omp.display_name(), "Oh My Pi");
+        assert_eq!(omp.steering_mode(), SteeringMode::TurnBoundary);
+        assert_eq!(
+            omp.reasoning_levels(),
+            &[
+                ReasoningLevel::Minimal,
+                ReasoningLevel::Low,
+                ReasoningLevel::Medium,
+                ReasoningLevel::High,
+                ReasoningLevel::XHigh,
+                ReasoningLevel::Max
+            ]
+        );
+
     }
 
     /// Catalogs serialized by engines that predate the `installed`/`enabled`

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -2,14 +2,15 @@
 //! stdio, protocol v1) and maps its session updates onto [`AgentEvent`]s.
 //!
 //! KEPT ONLY for agents built ground-up on ACP: Grok ([`AcpHarness::grok`],
-//! `grok agent stdio`), Hermes ([`AcpHarness::hermes`], `hermes acp`) and
-//! opencode ([`AcpHarness::opencode`], `opencode acp`) — plus pi
+//! `grok agent stdio`), Hermes ([`AcpHarness::hermes`], `hermes acp`),
+//! opencode ([`AcpHarness::opencode`], `opencode acp`) and Oh My Pi
+//! ([`AcpHarness::oh_my_pi`], `omp acp`) — plus pi
 //! ([`AcpHarness::pi`]) via the community `pi-acp` adapter until a native
 //! driver exists. Claude, Codex and Cursor moved to native drivers
 //! ([`crate::ClaudeHarness`], [`crate::CodexHarness`], [`crate::CursorHarness`])
 //! after adapter-mediated ACP kept manufacturing done-status bugs the native
 //! wires don't have (turn-hold bookkeeping vs the CLI's own eager result).
-//!
+
 //! - `initialize` (protocolVersion 1, fs/terminal capabilities declined) →
 //!   `session/new`, or `session/load` with a fresh-session fallback when
 //!   resuming; replayed history during a load is dropped (the doc already
@@ -200,6 +201,11 @@ fn npm_global_bins(exe: &str) -> Vec<PathBuf> {
     dirs.push(PathBuf::from("/usr/local/bin").join(exe));
     dirs
 }
+
+fn oh_my_pi_install_paths() -> Vec<PathBuf> {
+    npm_global_bins("omp")
+}
+
 
 fn grok_install_paths() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
@@ -494,6 +500,62 @@ fn opencode_spec() -> AcpAgentSpec {
     }
 }
 
+fn oh_my_pi_spec() -> AcpAgentSpec {
+    AcpAgentSpec {
+        id: HarnessId::OhMyPi,
+        display_name: "Oh My Pi",
+        executable: "omp",
+        env_override: "OMP_EXECUTABLE",
+        args: &["acp"],
+        npm_package: None,
+        extra_paths: oh_my_pi_install_paths,
+        cli_executable: "omp",
+        cli_extra_paths: oh_my_pi_install_paths,
+        install_hint: "omp (searched PATH, the login shell's PATH, npm global bins, \
+             and fnm/nvm/volta/pnpm/bun install dirs; install with \
+             `curl -fsSL https://omp.sh/install | sh`; set OMP_EXECUTABLE to override)",
+        // Models come from the agent's own provider config (`~/.omp`);
+        // the picker advertises a pass-through entry and the agent keeps whatever
+        // the user set up. Unknown ids are skipped by the config-option set.
+        models: || {
+            vec![Model {
+                id: "default".into(),
+                label: "omp default".into(),
+                description: Some("Runs the model configured in omp settings".into()),
+                reasoning_levels: vec![
+                    ReasoningLevel::Minimal,
+                    ReasoningLevel::Low,
+                    ReasoningLevel::Medium,
+                    ReasoningLevel::High,
+                    ReasoningLevel::XHigh,
+                    ReasoningLevel::Max,
+                ],
+                options: Vec::new(),
+            }]
+        },
+        // Native `omp acp` does not advertise `_session/steering`:
+        // turn boundaries. Thinking ladder is minimal→max ("off" has no zeron
+        // tier and is left to the agent default).
+        steering_mode: SteeringMode::TurnBoundary,
+        reasoning_levels: &[
+            ReasoningLevel::Minimal,
+            ReasoningLevel::Low,
+            ReasoningLevel::Medium,
+            ReasoningLevel::High,
+            ReasoningLevel::XHigh,
+            ReasoningLevel::Max,
+        ],
+        prompt_transform: identity_transform,
+        effort_values: default_effort_values,
+        ladder_extras: &[],
+        prompt_complete_extension: false,
+        prompt_stall: None,
+        stall_hint: "The agent process is likely wedged.",
+        http_sidecar: false,
+    }
+}
+
+
 /// Background-install managed npm adapters for agents whose CLI is present
 /// on this device, so a first chat never pays (or trips over) an npm run.
 /// Skips agents whose adapter is already resolvable; failures are logged and
@@ -602,6 +664,12 @@ impl AcpHarness {
     pub fn opencode() -> Self {
         Self::with_spec(opencode_spec())
     }
+
+    /// Oh My Pi over ACP — native `omp acp`. A different product from Pi.
+    pub fn oh_my_pi() -> Self {
+        Self::with_spec(oh_my_pi_spec())
+    }
+
 
     /// Use a fixed agent binary instead of PATH/known-location resolution.
     pub fn with_executable(mut self, path: impl Into<PathBuf>) -> Self {

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -5,12 +5,13 @@
 //! ([`CodexHarness`]), Cursor through a pinned @cursor/sdk shim
 //! ([`CursorHarness`]). The shared [`AcpHarness`] remains ONLY for agents
 //! built ground-up on ACP — Grok (`grok agent stdio`), Hermes
-//! (`hermes acp`) and opencode (`opencode acp`) — plus pi via the community
-//! `pi-acp` adapter until a native driver exists. Adapter-mediated ACP for
-//! claude/codex/cursor was retired: the
+//! (`hermes acp`), opencode (`opencode acp`) and Oh My Pi (`omp acp`) —
+//! plus pi via the community `pi-acp` adapter until a native driver exists.
+//! Adapter-mediated ACP for claude/codex/cursor was retired: the
 //! adapters held prompt turns open for background work the
 //! CLIs themselves settle eagerly, manufacturing done-status bugs the
 //! native wires don't have (decision record: docs/research/acp.md).
+
 
 use async_trait::async_trait;
 use futures::stream::BoxStream;

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -608,6 +608,24 @@ fn hermes_and_pi_descriptor_surfaces_match_registry_expectations() {
             zeron_proto::ReasoningLevel::Max,
         ]
     );
+
+    let omp = AcpHarness::oh_my_pi();
+    assert_eq!(omp.id(), HarnessId::OhMyPi);
+    assert_eq!(omp.display_name(), "Oh My Pi");
+    assert!(omp.supports_steering());
+    assert_eq!(omp.steering_mode(), SteeringMode::TurnBoundary);
+    assert_eq!(
+        omp.reasoning_levels(),
+        &[
+            zeron_proto::ReasoningLevel::Minimal,
+            zeron_proto::ReasoningLevel::Low,
+            zeron_proto::ReasoningLevel::Medium,
+            zeron_proto::ReasoningLevel::High,
+            zeron_proto::ReasoningLevel::XHigh,
+            zeron_proto::ReasoningLevel::Max,
+        ]
+    );
+
 }
 
 #[tokio::test]

--- a/crates/harness/tests/real_quiet_survey.rs
+++ b/crates/harness/tests/real_quiet_survey.rs
@@ -203,7 +203,9 @@ async fn real_all_harnesses_quiet_survey() {
         ("grok", AcpHarness::grok),
         ("hermes", AcpHarness::hermes),
         ("pi", AcpHarness::pi),
+        ("oh-my-pi", AcpHarness::oh_my_pi),
         ("opencode", AcpHarness::opencode),
+
     ];
     let mut failures: Vec<String> = Vec::new();
     for (name, ctor) in agents {

--- a/crates/harness/tests/shell_env_resolution.rs
+++ b/crates/harness/tests/shell_env_resolution.rs
@@ -24,6 +24,8 @@ async fn cli_on_login_shell_path_only_is_resolved() {
     write_executable(&shell_bin.join("hermes"), "#!/bin/sh\nexit 0\n");
     write_executable(&shell_bin.join("pi-acp"), "#!/bin/sh\nexit 0\n");
     write_executable(&shell_bin.join("claude"), "#!/bin/sh\nexit 0\n");
+    write_executable(&shell_bin.join("omp"), "#!/bin/sh\nexit 0\n");
+
 
     // A $SHELL whose init shapes PATH — the shape resolution must survive.
     let fake_shell = dir.path().join("fake-shell");
@@ -49,6 +51,8 @@ async fn cli_on_login_shell_path_only_is_resolved() {
         std::env::remove_var("HERMES_EXECUTABLE");
         std::env::remove_var("PI_ACP_EXECUTABLE");
         std::env::remove_var("CLAUDE_CODE_EXECUTABLE");
+        std::env::remove_var("OMP_EXECUTABLE");
+
         std::env::remove_var("ZERON_NO_LOGIN_SHELL");
     }
 
@@ -75,4 +79,9 @@ async fn cli_on_login_shell_path_only_is_resolved() {
         .launch_program()
         .expect("pi-acp resolves via login-shell PATH");
     assert_eq!(pi, shell_bin.join("pi-acp"), "{pi:?}");
+    let omp = AcpHarness::oh_my_pi()
+        .launch_program()
+        .expect("omp resolves via login-shell PATH");
+    assert_eq!(omp, shell_bin.join("omp"), "{omp:?}");
+
 }

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -16,6 +16,9 @@ pub enum HarnessId {
     Pi,
     /// SST's opencode agent, driven over ACP (`opencode acp`).
     Opencode,
+    /// Oh My Pi (`omp`), a separate product, driven over ACP (`omp acp`).
+    OhMyPi,
+
     /// Test harness; never shown in production pickers.
     Mock,
 }

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -3334,9 +3334,10 @@ pub(crate) fn harness_brand_icon(harness: HarnessId) -> (&'static str, Option<gp
         HarnessId::Grok => (crate::icons::GROK_MARK, None),
         // Nous Research's mark (the Hermes product icon), monochrome.
         HarnessId::Hermes => (crate::icons::HERMES_MARK, None),
-        HarnessId::Pi => (crate::icons::PI_MARK, None),
+        HarnessId::Pi | HarnessId::OhMyPi => (crate::icons::PI_MARK, None),
         // The pixel-"o" from opencode's wordmark (their favicon), monochrome.
         HarnessId::Opencode => (crate::icons::OPENCODE_MARK, None),
+
     }
 }
 

--- a/crates/ui/src/settings/accounts.rs
+++ b/crates/ui/src/settings/accounts.rs
@@ -1212,8 +1212,9 @@ impl Render for AccountsPage {
             HarnessId::Cursor => (crate::icons::CURSOR_MARK, None),
             HarnessId::Grok => (crate::icons::GROK_MARK, None),
             HarnessId::Hermes => (crate::icons::HERMES_MARK, None),
-            HarnessId::Pi => (crate::icons::PI_MARK, None),
+            HarnessId::Pi | HarnessId::OhMyPi => (crate::icons::PI_MARK, None),
             HarnessId::Opencode => (crate::icons::OPENCODE_MARK, None),
+
             _ => (
                 crate::icons::CLAUDE_MARK,
                 Some(crate::icons::claude_brand()),

--- a/crates/ui/src/settings/harnesses.rs
+++ b/crates/ui/src/settings/harnesses.rs
@@ -39,8 +39,10 @@ pub fn blurb(harness: HarnessId) -> &'static str {
         HarnessId::Grok => "xAI's Grok Build agent (grok CLI).",
         HarnessId::Hermes => "Nous Research's Hermes Agent (hermes CLI).",
         HarnessId::Pi => "The pi coding agent (pi CLI).",
+        HarnessId::OhMyPi => "Oh My Pi, driven through native omp acp.",
         HarnessId::Opencode => "SST's opencode agent (opencode CLI).",
         HarnessId::Mock => "Scripted test harness.",
+
     }
 }
 
@@ -53,8 +55,10 @@ pub fn cli_name(harness: HarnessId) -> &'static str {
         HarnessId::Grok => "grok",
         HarnessId::Hermes => "hermes",
         HarnessId::Pi => "pi",
+        HarnessId::OhMyPi => "omp",
         HarnessId::Opencode => "opencode",
         HarnessId::Mock => "mock",
+
     }
 }
 

--- a/docs/research/acp.md
+++ b/docs/research/acp.md
@@ -45,6 +45,9 @@
   ride pi's own provider config (catalog advertises a `default` pass-through
   entry); thinking ladder minimal→max maps onto zeron's levels via the
   generic `thought_level` preference ladder ("off" has no zeron tier).
+  `AcpHarness::oh_my_pi()` is a separate product (`omp acp`, native ACP,
+  `OMP_EXECUTABLE` overrides); it must not share Pi's slot.
+
 - **ACP is the source of truth for model lists** (2026-08-08; preference
   order inverted 2026-08-09): `models()` runs a short-lived probe
   (initialize → `session/new`, the `discover_commands` pattern) and reads


### PR DESCRIPTION
I'm daily driving omp and was missing the selector for it.

| Agent | Launch | Enablement |
| --- | --- | --- |
| Pi | `pi-acp` / `npx -y pi-acp@0.0.33` | stock `pi` CLI |
| Oh My Pi | `omp acp` | `omp` CLI |

Both stay opt-in in Settings → Agents. Existing Pi chats keep the `pi` harness id. Oh My Pi is a new `oh-my-pi` id. `PI_ACP_EXECUTABLE` still forces the Pi adapter; `OMP_EXECUTABLE` only picks the Oh My Pi binary.

`cargo test -p zeron-harness --test shell_env_resolution --test acp -- --skip real_`
`cargo test -p zeron-engine --lib registry`