### PR TITLE
opencode: ACP harness with subagent virtualization via the sidecar event bus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9173,6 +9173,7 @@ dependencies = [
  "base64",
  "futures",
  "libc",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/engine/src/agent_accounts.rs
+++ b/crates/engine/src/agent_accounts.rs
@@ -860,15 +860,14 @@ impl AgentAccounts {
                 let output = lock(&output);
                 // The cursor shim reports failures as a JSONL fatal frame;
                 // codex prints plain text. Surface the human part.
-                scan_shim_fatal(&output)
-                    .unwrap_or_else(|| {
-                        output
-                            .trim()
-                            .lines()
-                            .last()
-                            .unwrap_or("sign-in failed")
-                            .to_string()
-                    })
+                scan_shim_fatal(&output).unwrap_or_else(|| {
+                    output
+                        .trim()
+                        .lines()
+                        .last()
+                        .unwrap_or("sign-in failed")
+                        .to_string()
+                })
             };
             return Ok(AgentLoginPoll {
                 status: AgentLoginStatus::Error,
@@ -1364,6 +1363,7 @@ fn harness_slug(harness: HarnessId) -> &'static str {
         HarnessId::Grok => "grok",
         HarnessId::Hermes => "hermes",
         HarnessId::Pi => "pi",
+        HarnessId::Opencode => "opencode",
         HarnessId::Mock => "mock",
     }
 }
@@ -1515,7 +1515,10 @@ fn parse_cursor_auth(auth: serde_json::Value) -> Option<Detected> {
         account_key,
         profile: SlotProfile {
             email: email.unwrap_or_else(|| {
-                let tail: String = api_key.chars().skip(api_key.len().saturating_sub(4)).collect();
+                let tail: String = api_key
+                    .chars()
+                    .skip(api_key.len().saturating_sub(4))
+                    .collect();
                 format!("API key ·…{tail}")
             }),
             display_name: None,
@@ -1742,7 +1745,14 @@ mod tests {
         assert_eq!(detected.account_key, "dev@example.com");
         assert_eq!(detected.profile.email, "dev@example.com");
         assert_eq!(detected.profile.auth_kind, AgentAuthKind::Oauth);
-        assert!(detected.profile.plan.as_deref().unwrap().starts_with("Key expires"));
+        assert!(
+            detected
+                .profile
+                .plan
+                .as_deref()
+                .unwrap()
+                .starts_with("Key expires")
+        );
         assert!(cursor_key_usable(&live));
 
         let expired = serde_json::json!({

--- a/crates/engine/src/registry.rs
+++ b/crates/engine/src/registry.rs
@@ -453,6 +453,24 @@ pub fn default_registry() -> HarnessRegistry {
         Box::new(|| zeron_harness::AcpHarness::pi().installed()),
         Box::new(|| Ok(Arc::new(zeron_harness::AcpHarness::pi()) as Arc<dyn Harness>)),
     );
+    // opencode over ACP (`opencode acp`), same lazy pattern: the static
+    // descriptor mirrors AcpHarness::opencode() exactly. No steering
+    // extension (turn boundaries) and no effort ladder — opencode exposes no
+    // thought_level config over ACP today (effort stays per-model in its own
+    // config).
+    registry.register_lazy(
+        HarnessDescriptor {
+            id: HarnessId::Opencode,
+            name: "OpenCode".into(),
+            supports_steering: true,
+            steering_mode: SteeringMode::TurnBoundary,
+            reasoning_levels: Vec::new(),
+            installed: true,
+            enabled: None,
+        },
+        Box::new(|| zeron_harness::AcpHarness::opencode().installed()),
+        Box::new(|| Ok(Arc::new(zeron_harness::AcpHarness::opencode()) as Arc<dyn Harness>)),
+    );
     registry
 }
 
@@ -509,7 +527,8 @@ mod tests {
                 HarnessId::Cursor,
                 HarnessId::Grok,
                 HarnessId::Hermes,
-                HarnessId::Pi
+                HarnessId::Pi,
+                HarnessId::Opencode
             ]
         );
         assert!(registry.resolve(HarnessId::Mock).is_ok());
@@ -543,6 +562,11 @@ mod tests {
         assert_eq!(hermes.display_name(), "Hermes");
         assert_eq!(hermes.steering_mode(), SteeringMode::TurnBoundary);
         assert!(hermes.reasoning_levels().is_empty());
+        let opencode = registry.resolve(HarnessId::Opencode).unwrap();
+        assert_eq!(opencode.id(), HarnessId::Opencode);
+        assert_eq!(opencode.display_name(), "OpenCode");
+        assert_eq!(opencode.steering_mode(), SteeringMode::TurnBoundary);
+        assert!(opencode.reasoning_levels().is_empty());
         let pi = registry.resolve(HarnessId::Pi).unwrap();
         assert_eq!(pi.id(), HarnessId::Pi);
         assert_eq!(pi.display_name(), "Pi");

--- a/crates/harness/Cargo.toml
+++ b/crates/harness/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 [dependencies]
 zeron-proto.workspace = true
 base64 = "0.22"
+reqwest.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 uuid.workspace = true

--- a/crates/harness/examples/opencode_subagent_probe.rs
+++ b/crates/harness/examples/opencode_subagent_probe.rs
@@ -1,0 +1,104 @@
+//! Live probe: drive the real opencode CLI through AcpHarness and print the
+//! event stream, verifying task-chip correlation + the sidecar-bus-tailed
+//! subagent transcript end-to-end. Needs `opencode` on PATH (or
+//! OPENCODE_EXECUTABLE) with a model provider configured in the target cwd —
+//! the rig recipe uses a mock OpenAI-compatible provider in the workspace's
+//! opencode.json, so no real login is required:
+//!
+//!     cargo run -p zeron-harness --example opencode_subagent_probe -- /tmp/oc-probe/workspace
+//!
+//! Prompt content is irrelevant with the mock provider (it scripts a task
+//! spawn on the first parent round); against a real provider, ask for one
+//! `task` explicitly.
+
+use futures::StreamExt;
+use tokio::sync::{mpsc, oneshot};
+use zeron_harness::{AcpHarness, CancellationToken, Harness, RunControls};
+use zeron_proto::{AgentEvent, RunRequest, SandboxLevel, UserInputAnswer};
+
+#[tokio::main]
+async fn main() {
+    let cwd = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/tmp/probe-opencode-viz".into());
+    std::fs::create_dir_all(&cwd).unwrap();
+    let (_steer_tx, steering) = mpsc::channel(8);
+    let controls = RunControls {
+        request_input: Box::new(move |questions| {
+            let (tx, rx) = oneshot::channel();
+            let answers: Vec<UserInputAnswer> = questions
+                .iter()
+                .map(|q| UserInputAnswer {
+                    question_id: q.id.clone(),
+                    labels: q.options.first().cloned().into_iter().collect(),
+                })
+                .collect();
+            let _ = tx.send(answers);
+            rx
+        }),
+        steering,
+        interrupt: CancellationToken::new(),
+    };
+    // Optional second arg overrides the prompt (e.g. the mock rig's
+    // "TWO subagents" variant exercising concurrent binding).
+    let prompt = std::env::args().nth(2).unwrap_or_else(|| {
+        "Use the task tool to launch ONE general subagent with description \
+         'Viz probe' and prompt: 'Run `echo viz-probe-ok`, then reply with the \
+         word finished.'. Tell me its result."
+            .into()
+    });
+    let request = RunRequest {
+        prompt,
+        harness: None,
+        model: None,
+        reasoning: None,
+        model_options: serde_json::Map::new(),
+        cwd,
+        sandbox: SandboxLevel::WorkspaceWrite,
+        auto_approve: true,
+        attachments: Vec::new(),
+        resume: None,
+    };
+    let mut stream = AcpHarness::opencode()
+        .run(request, controls)
+        .await
+        .expect("run starts");
+    // stderr is unbuffered; a SIGTERM'd run still shows everything.
+    let mut tagged = 0u32;
+    let mut parent_done = false;
+    loop {
+        // The session stays alive for the steering mailbox after the parent
+        // turn settles — bound the wait for the subagent's tagged Done.
+        let ev = match tokio::time::timeout(std::time::Duration::from_secs(90), stream.next()).await
+        {
+            Ok(Some(ev)) => ev,
+            Ok(None) => break,
+            Err(_) => {
+                eprintln!("--- timed out waiting (parent_done={parent_done}, tagged={tagged})");
+                std::process::exit(2);
+            }
+        };
+        match ev {
+            Ok(AgentEvent::Subagent {
+                parent_tool_use_id,
+                event,
+            }) => {
+                tagged += 1;
+                eprintln!("SUB[{parent_tool_use_id}] {event:?}");
+                if matches!(*event, AgentEvent::Done { .. }) && parent_done {
+                    eprintln!("--- tagged events total: {tagged}");
+                    std::process::exit(0);
+                }
+            }
+            Ok(AgentEvent::Done { status, .. }) => {
+                parent_done = true;
+                eprintln!("EV Done({status:?}) [parent]");
+            }
+            Ok(AgentEvent::TextDelta { text }) => eprintln!("TXT {}", text.trim_end()),
+            Ok(AgentEvent::ReasoningDelta { .. }) => {}
+            Ok(other) => eprintln!("EV {other:?}"),
+            Err(e) => eprintln!("ERR {e}"),
+        }
+    }
+    eprintln!("--- stream ended; tagged events total: {tagged}");
+}

--- a/crates/harness/src/acp/mod.rs
+++ b/crates/harness/src/acp/mod.rs
@@ -2,9 +2,10 @@
 //! stdio, protocol v1) and maps its session updates onto [`AgentEvent`]s.
 //!
 //! KEPT ONLY for agents built ground-up on ACP: Grok ([`AcpHarness::grok`],
-//! `grok agent stdio`) and Hermes ([`AcpHarness::hermes`], `hermes acp`) —
-//! plus pi ([`AcpHarness::pi`]) via the community `pi-acp` adapter until a
-//! native driver exists. Claude, Codex and Cursor moved to native drivers
+//! `grok agent stdio`), Hermes ([`AcpHarness::hermes`], `hermes acp`) and
+//! opencode ([`AcpHarness::opencode`], `opencode acp`) — plus pi
+//! ([`AcpHarness::pi`]) via the community `pi-acp` adapter until a native
+//! driver exists. Claude, Codex and Cursor moved to native drivers
 //! ([`crate::ClaudeHarness`], [`crate::CodexHarness`], [`crate::CursorHarness`])
 //! after adapter-mediated ACP kept manufacturing done-status bugs the native
 //! wires don't have (turn-hold bookkeeping vs the CLI's own eager result).
@@ -28,6 +29,7 @@
 
 mod normalize;
 mod subagent;
+mod subagent_opencode;
 
 use std::collections::VecDeque;
 use std::path::PathBuf;
@@ -52,6 +54,7 @@ use crate::jsonrpc::{Incoming, RpcClient};
 use crate::{Harness, HarnessError, RunControls, Signal, send_signal, shutdown_child};
 use normalize::{map_update, parse_commands, preferred_allow_option};
 use subagent::SubagentTracker;
+use subagent_opencode::OpencodeTracker;
 
 /// Per-agent configuration: which binary to spawn and what to tell the picker.
 struct AcpAgentSpec {
@@ -108,10 +111,23 @@ struct AcpAgentSpec {
     /// a dead update check) — surface a visible error chip instead of
     /// indefinite Working.
     prompt_stall: Option<Duration>,
+    /// The agent's ACP process doubles as its own HTTP server (opencode):
+    /// runs pass `--port <free>` and tail the `/event` SSE bus for subagent
+    /// transcripts, which never ride the ACP wire. A failed port pick (or a
+    /// server that never binds) degrades to chip + final output.
+    http_sidecar: bool,
 }
 
 fn identity_transform(_reasoning: Option<ReasoningLevel>, text: &str) -> String {
     text.to_owned()
+}
+
+/// A kernel-assigned free localhost port, released for the child to claim.
+fn free_localhost_port() -> Option<u16> {
+    std::net::TcpListener::bind(("127.0.0.1", 0))
+        .and_then(|l| l.local_addr())
+        .map(|a| a.port())
+        .ok()
 }
 
 /// PATH + login-shell + extra dirs + node-version-manager scan for a binary.
@@ -246,6 +262,7 @@ fn grok_spec() -> AcpAgentSpec {
         // `_meta.promptId`, just ahead of the RPC response.
         prompt_complete_extension: true,
         prompt_stall: Some(Duration::from_secs(30)),
+        http_sidecar: false,
     }
 }
 
@@ -310,6 +327,7 @@ fn hermes_spec() -> AcpAgentSpec {
         ladder_extras: &[],
         prompt_complete_extension: false,
         prompt_stall: None,
+        http_sidecar: false,
     }
 }
 
@@ -365,6 +383,77 @@ fn pi_spec() -> AcpAgentSpec {
         ladder_extras: &[],
         prompt_complete_extension: false,
         prompt_stall: None,
+        http_sidecar: false,
+    }
+}
+
+fn opencode_install_paths() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        dirs.push(home.join(".opencode").join("bin").join("opencode"));
+        dirs.push(home.join(".local").join("bin").join("opencode"));
+        dirs.push(home.join(".npm-global").join("bin").join("opencode"));
+    }
+    dirs.push(PathBuf::from("/opt/homebrew/bin/opencode"));
+    dirs.push(PathBuf::from("/usr/local/bin/opencode"));
+    dirs
+}
+
+fn opencode_spec() -> AcpAgentSpec {
+    AcpAgentSpec {
+        id: HarnessId::Opencode,
+        display_name: "OpenCode",
+        executable: "opencode",
+        env_override: "OPENCODE_EXECUTABLE",
+        args: &["acp"],
+        // The opencode-ai npm package ships a NATIVE platform binary (its
+        // `bin` entry is `opencode.exe` swapped in by postinstall), so the
+        // managed `node <entry>` adapter path can't launch it — the CLI
+        // itself is the ACP server, installed like grok/hermes.
+        npm_package: None,
+        extra_paths: opencode_install_paths,
+        cli_executable: "opencode",
+        cli_extra_paths: opencode_install_paths,
+        install_hint: "opencode (searched PATH, the login shell's PATH, ~/.opencode/bin, \
+             ~/.local/bin, ~/.npm-global/bin, /opt/homebrew/bin, /usr/local/bin, and \
+             fnm/nvm/volta/pnpm/bun install dirs; install with \
+             `curl -fsSL https://opencode.ai/install | bash` or \
+             `npm install -g opencode-ai`, then `opencode auth login`; set \
+             OPENCODE_EXECUTABLE to override)",
+        // opencode routes models through its provider config (`opencode auth
+        // login` + opencode.json); the always-advertised OpenCode Zen frees
+        // anchor the static fallback. Ids the agent doesn't advertise are
+        // skipped by the config-option set (verified: the `model` config
+        // option lists every configured provider, no auth needed to probe).
+        models: || {
+            vec![
+                Model {
+                    id: "opencode/big-pickle".into(),
+                    label: "Big Pickle".into(),
+                    description: Some("OpenCode Zen's flagship coding model".into()),
+                    reasoning_levels: Vec::new(),
+                    options: Vec::new(),
+                },
+                Model {
+                    id: "opencode/deepseek-v4-flash-free".into(),
+                    label: "DeepSeek V4 Flash (free)".into(),
+                    description: Some("Free tier on OpenCode Zen".into()),
+                    reasoning_levels: Vec::new(),
+                    options: Vec::new(),
+                },
+            ]
+        },
+        // No `_session/steering` extension (1.18.18): turn boundaries.
+        steering_mode: SteeringMode::TurnBoundary,
+        // No `thought_level` config option over ACP today — effort stays
+        // with opencode's own per-model config; revisit when advertised.
+        reasoning_levels: &[],
+        prompt_transform: identity_transform,
+        effort_values: default_effort_values,
+        ladder_extras: &[],
+        prompt_complete_extension: false,
+        prompt_stall: None,
+        http_sidecar: true,
     }
 }
 
@@ -470,6 +559,11 @@ impl AcpHarness {
     /// pi's RPC mode.
     pub fn pi() -> Self {
         Self::with_spec(pi_spec())
+    }
+
+    /// opencode (`opencode acp`) — SST's native ACP agent.
+    pub fn opencode() -> Self {
+        Self::with_spec(opencode_spec())
     }
 
     /// Use a fixed agent binary instead of PATH/known-location resolution.
@@ -606,10 +700,12 @@ impl AcpHarness {
         &self,
         cwd: Option<&str>,
         block_on_install: bool,
+        extra_args: &[String],
     ) -> Result<(Child, crate::StderrTail), HarnessError> {
         let (exe, args) = self.resolve_program(block_on_install).await?;
         let mut cmd = Command::new(&exe);
         cmd.args(args);
+        cmd.args(extra_args);
         crate::compose_child_path(&mut cmd, &exe);
         if let Some(cwd) = cwd.filter(|c| !c.is_empty()) {
             cmd.current_dir(cwd);
@@ -645,7 +741,7 @@ impl AcpHarness {
     /// refuses sessions before login still surfaces whatever the handshake
     /// advertised.
     async fn discover_commands(&self) -> Result<Vec<SlashCommand>, HarnessError> {
-        let (mut child, _stderr) = self.spawn_agent(None, false).await?;
+        let (mut child, _stderr) = self.spawn_agent(None, false, &[]).await?;
         let (client, mut incoming) = match (child.stdin.take(), child.stdout.take()) {
             (Some(stdin), Some(stdout)) => RpcClient::new(stdin, stdout),
             _ => {
@@ -709,7 +805,7 @@ impl AcpHarness {
     /// wire is the source of truth — the spec's static catalog only enriches
     /// matching entries and names the pick when the agent advertises nothing.
     async fn discover_models(&self) -> Result<Vec<Model>, HarnessError> {
-        let (mut child, _stderr) = self.spawn_agent(None, false).await?;
+        let (mut child, _stderr) = self.spawn_agent(None, false, &[]).await?;
         let (client, _incoming) = match (child.stdin.take(), child.stdout.take()) {
             (Some(stdin), Some(stdout)) => RpcClient::new(stdin, stdout),
             _ => {
@@ -1054,7 +1150,18 @@ impl Harness for AcpHarness {
         request: RunRequest,
         controls: RunControls,
     ) -> Result<BoxStream<'static, Result<AgentEvent, HarnessError>>, HarnessError> {
-        let (mut child, stderr_tail) = self.spawn_agent(Some(&request.cwd), true).await?;
+        // An http_sidecar agent (opencode) gets a per-run port: the default
+        // (4096) is shared, and a losing concurrent bind silently drops the
+        // server the subagent viz tails. The pick-then-release race is
+        // acceptable — a lost port only degrades transcripts to final output.
+        let sidecar_port = self.spec.http_sidecar.then(free_localhost_port).flatten();
+        let extra_args = match sidecar_port {
+            Some(port) => vec!["--port".to_owned(), port.to_string()],
+            None => Vec::new(),
+        };
+        let (mut child, stderr_tail) = self
+            .spawn_agent(Some(&request.cwd), true, &extra_args)
+            .await?;
         let stdin = child
             .stdin
             .take()
@@ -1079,6 +1186,7 @@ impl Harness for AcpHarness {
             prompt_complete_extension: self.spec.prompt_complete_extension,
             prompt_stall: self.spec.prompt_stall,
             sessions_root: self.sessions_root.clone(),
+            sidecar_port,
             interrupt_grace: self.interrupt_grace,
             kill_grace: self.kill_grace,
             handshake_timeout: self.handshake_timeout,
@@ -1109,6 +1217,8 @@ struct Session {
     prompt_stall: Option<Duration>,
     /// Sessions-root override for the subagent transcript tail (tests).
     sessions_root: Option<PathBuf>,
+    /// The http_sidecar port this run's agent was told to bind (opencode).
+    sidecar_port: Option<u16>,
     prompt_transform: fn(Option<ReasoningLevel>, &str) -> String,
     effort_values: fn(Option<ReasoningLevel>, Option<&str>) -> Vec<&'static str>,
     interrupt_grace: Duration,
@@ -1353,6 +1463,24 @@ fn config_option_sets(
     sets
 }
 
+/// The per-agent subagent correlator: grok's spawn-tool + disk-tail tracker
+/// (inert for agents that never emit `subagent_*` updates), or opencode's
+/// task-chip + sidecar-bus tracker. Both observe the raw updates ahead of
+/// [`map_update`]; their tagged events flow from their own tasks.
+enum SubagentObserver {
+    Grok(SubagentTracker),
+    Opencode(OpencodeTracker),
+}
+
+impl SubagentObserver {
+    fn observe(&mut self, update: &Value) {
+        match self {
+            SubagentObserver::Grok(tracker) => tracker.observe(update),
+            SubagentObserver::Opencode(tracker) => tracker.observe(update),
+        }
+    }
+}
+
 /// The events of one notification, session-filtered. `session/update` maps
 /// per [`map_update`]; `_x.ai/session_notification` is grok's extension
 /// channel — same `{sessionId, update}` envelope, but its updates (the
@@ -1363,7 +1491,7 @@ fn session_update_events(
     method: &str,
     params: &Value,
     session_id: &str,
-    subagents: &mut SubagentTracker,
+    subagents: &mut SubagentObserver,
 ) -> Vec<AgentEvent> {
     if params.get("sessionId").and_then(Value::as_str) != Some(session_id) {
         return Vec::new();
@@ -1582,7 +1710,6 @@ fn handle_server_request_live(
     Vec::new()
 }
 
-
 /// Await a setup request while draining incoming messages, so a `session/load`
 /// whose replay outruns the incoming channel's capacity can't deadlock the
 /// reader. Replayed `session/update`s are dropped (the doc already holds the
@@ -1650,7 +1777,6 @@ fn track_turn_signals(
     }
 }
 
-
 /// A mid-turn `_session/steering` call. `idleBehavior: promptRequired`
 /// covers the turn-ended race: the agent hands the text back instead of
 /// firing an untracked turn.
@@ -1682,6 +1808,7 @@ async fn run_session(session: Session) {
         prompt_complete_extension,
         prompt_stall,
         sessions_root,
+        sidecar_port,
         prompt_transform,
         effort_values,
         interrupt_grace,
@@ -1885,9 +2012,22 @@ async fn run_session(session: Session) {
         return;
     }
 
-    // Grok subagent correlation + transcript tails; inert for agents that
-    // never emit the `subagent_*` extension updates.
-    let mut subagents = SubagentTracker::new(session_id.clone(), event_tx.clone(), sessions_root);
+    // Subagent correlation + transcript tails: opencode rides its sidecar
+    // event bus; everything else gets the grok tracker (inert for agents
+    // that never emit the `subagent_*` extension updates).
+    let mut subagents = if harness == HarnessId::Opencode {
+        SubagentObserver::Opencode(OpencodeTracker::new(
+            session_id.clone(),
+            event_tx.clone(),
+            sidecar_port.map(|p| format!("http://127.0.0.1:{p}")),
+        ))
+    } else {
+        SubagentObserver::Grok(SubagentTracker::new(
+            session_id.clone(),
+            event_tx.clone(),
+            sessions_root,
+        ))
+    };
 
     // ---- main loop --------------------------------------------------------
     // Prompt-completion settlement state (the prompt-complete extension):
@@ -1910,8 +2050,7 @@ async fn run_session(session: Session) {
         prompt_stall.map(|d| tokio::time::Instant::now() + d);
     let mut turn: Option<BoxFuture<'static, Result<Value, HarnessError>>> = Some({
         prompt_seq += 1;
-        current_prompt_id =
-            prompt_complete_extension.then(|| format!("zeron-p{prompt_seq}"));
+        current_prompt_id = prompt_complete_extension.then(|| format!("zeron-p{prompt_seq}"));
         prompt_turn(
             client.clone(),
             session_id.clone(),

--- a/crates/harness/src/acp/normalize.rs
+++ b/crates/harness/src/acp/normalize.rs
@@ -94,11 +94,7 @@ fn tool_diff(update: &Value) -> Option<ToolDiff> {
 /// The grok-native tool name stamped on a tool call's `_meta` (`x.ai/tool`,
 /// present on every grok tool_call — verified live, 1.0.4).
 pub(crate) fn xai_tool_name(update: &Value) -> Option<&str> {
-    update
-        .get("_meta")?
-        .get("x.ai/tool")?
-        .get("name")?
-        .as_str()
+    update.get("_meta")?.get("x.ai/tool")?.get("name")?.as_str()
 }
 
 /// First location path (`locations: [{path, line?}]`), for read/edit calls.
@@ -280,6 +276,37 @@ fn typed_call(update: &Value) -> ToolCall {
                 .unwrap_or_else(|| "Agent".into()),
             input: raw.cloned(),
         },
+        // opencode's subagent spawn (`task` tool — rawInput carries
+        // description/prompt/subagent_type): same naming as grok's, so the
+        // chip and its subagent tab say what the agent is doing.
+        _ if raw.is_some_and(|r| r.get("subagent_type").is_some() && r.get("prompt").is_some()) => {
+            ToolCall::Unknown {
+                name: raw_str("description")
+                    .map(|d| format!("Agent: {d}"))
+                    .unwrap_or_else(|| "Agent".into()),
+                input: raw.cloned(),
+            }
+        }
+        // Its completion drops rawInput but keeps a title (the description),
+        // which would re-type the chip to a bare Unknown and cost it the
+        // Agent icon/label. The rawOutput metadata (child + parent session
+        // ids) still marks the spawn — keep the naming.
+        _ if update
+            .get("rawOutput")
+            .and_then(|r| r.get("metadata"))
+            .is_some_and(|m| {
+                m.get("sessionId").is_some() && m.get("parentSessionId").is_some()
+            }) =>
+        {
+            ToolCall::Unknown {
+                name: if title.is_empty() {
+                    "Agent".into()
+                } else {
+                    format!("Agent: {title}")
+                },
+                input: raw.cloned(),
+            }
+        }
         _ if raw_str("_toolName").as_deref() == Some("task") => ToolCall::Unknown {
             name: raw_str("description")
                 .filter(|d| d != "Subagent task")
@@ -433,7 +460,6 @@ pub(crate) fn parse_commands(value: Option<&Value>) -> Vec<SlashCommand> {
         })
         .collect()
 }
-
 
 /// `session/request_permission` options (`{optionId, name, kind}`) → the
 /// preferred auto-approve choice: `allow_always` > `allow_once` > first.
@@ -834,5 +860,48 @@ mod tests {
                 },
             }]
         );
+    }
+
+    #[test]
+    fn opencode_task_keeps_agent_naming_across_frames() {
+        // The rawInput frame (in_progress) names the chip off the spawn args.
+        let update = json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "t1",
+            "status": "in_progress",
+            "kind": "think",
+            "title": "Viz probe",
+            "rawInput": {
+                "description": "Viz probe",
+                "prompt": "run the probe",
+                "subagent_type": "general",
+            },
+        });
+        assert!(matches!(
+            map_update(&update).as_slice(),
+            [AgentEvent::ToolCall { call: ToolCall::Unknown { name, .. }, .. }]
+                if name == "Agent: Viz probe"
+        ));
+        // The completion drops rawInput (title = the bare description); the
+        // rawOutput metadata still marks the spawn — naming survives.
+        let update = json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "t1",
+            "status": "completed",
+            "title": "Viz probe",
+            "content": [{"type": "content", "content": {"type": "text",
+                "text": "<task id=\"ses_c\" state=\"completed\">\n<task_result>\nfinished\n</task_result>\n</task>"}}],
+            "rawOutput": {
+                "output": "<task id=\"ses_c\" state=\"completed\">\n<task_result>\nfinished\n</task_result>\n</task>",
+                "metadata": {"parentSessionId": "ses_p", "sessionId": "ses_c"},
+            },
+        });
+        assert!(matches!(
+            map_update(&update).as_slice(),
+            [
+                AgentEvent::ToolCall { call: ToolCall::Unknown { name, .. }, .. },
+                AgentEvent::ToolResult { is_error: false, .. },
+            ] if name == "Agent: Viz probe"
+        ));
     }
 }

--- a/crates/harness/src/acp/subagent_opencode.rs
+++ b/crates/harness/src/acp/subagent_opencode.rs
@@ -1,0 +1,1075 @@
+//! OpenCode subagent visualization on the ACP path.
+//!
+//! opencode's `task` tool call rides the parent's `session/update` stream
+//! (kind `think`, `rawInput: {description, prompt, subagent_type}`), but the
+//! child session's interior transcript never appears on the ACP wire — the
+//! parent only sees the completion's `<task_result>` text. The transcript IS
+//! available live from the process itself: `opencode acp` always doubles as
+//! opencode's HTTP server (zeron passes `--port <free>` to dodge the shared
+//! default 4096, where a losing concurrent bind silently drops the server),
+//! and its `/event` SSE bus broadcasts every session's `session.created` /
+//! `message.updated` / `message.part.updated` / `message.part.delta` events —
+//! child sessions included, token-level (verified live, 1.18.18; storage
+//! moved to SQLite in 1.18, so there is no JSONL to tail grok-style).
+//!
+//! Correlation: a `task` tool call registers a pending chip; the bus's
+//! `session.created` for a child (`parentID` = the parent ACP session, title
+//! `"{description} (@{agent} subagent)"`) binds by description, else FIFO —
+//! and the task completion's `rawOutput.metadata.sessionId` is the
+//! authoritative late binding. The bound child's bus traffic maps to tagged
+//! [`AgentEvent::Subagent`] events; the ACP task completion settles the chip
+//! with a tagged Done (`task` runs synchronously — the child always finishes
+//! before its chip does). The bus is vendor-private: every parse fails soft,
+//! degrading to chip + final `<task_result>` output.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::sync::mpsc;
+use zeron_proto::{AgentEvent, DoneStatus, TodoItem, ToolCall};
+
+use crate::HarnessError;
+
+use super::normalize::{OUTPUT_CAP, cap_text};
+
+/// Budget on the first `/event` connect: the server binds a few seconds into
+/// the process's life, well inside this window.
+const CONNECT_ATTEMPTS: u32 = 120;
+const CONNECT_POLL: Duration = Duration::from_millis(250);
+/// Grace between the ACP task completion and the tagged Done, letting the
+/// child's last bus frames (an independent channel) land in order.
+const SETTLE_DRAIN: Duration = Duration::from_millis(400);
+
+/// Wrap an event as subagent-attributed traffic.
+fn tag(parent: &str, event: AgentEvent) -> AgentEvent {
+    AgentEvent::Subagent {
+        parent_tool_use_id: parent.to_owned(),
+        event: Box::new(event),
+    }
+}
+
+fn done(status: DoneStatus) -> AgentEvent {
+    AgentEvent::Done {
+        status,
+        result: None,
+        error: None,
+        session_id: None,
+    }
+}
+
+/// A `task` chip seen on the ACP wire, awaiting a child session.
+struct PendingSpawn {
+    tool_call_id: String,
+    description: String,
+}
+
+/// A bus `session.created` that arrived before any chip could be bound
+/// (defensive: the chip's rawInput update precedes tool execution today).
+struct UnboundChild {
+    title: String,
+}
+
+/// What a bound child's bus traffic has produced so far.
+#[derive(Default)]
+struct ChildState {
+    /// The spawn chip this child streams to.
+    parent_tool_use_id: String,
+    /// messageID → is-assistant (user prompt echoes must not render).
+    assistant_messages: HashMap<String, bool>,
+    /// partID → streaming state (dedup between snapshots and deltas).
+    parts: HashMap<String, PartState>,
+    /// Any transcript reached the doc — the completion fallback text would
+    /// only duplicate it.
+    saw_transcript: bool,
+    /// Chip settled (tagged Done sent or scheduled); late traffic drops.
+    done: bool,
+}
+
+#[derive(Default)]
+struct PartState {
+    /// "text" | "reasoning" | "tool" (unknown kinds are never registered).
+    kind: String,
+    /// Bytes of part text already emitted (snapshots resend the full text;
+    /// deltas append).
+    emitted: usize,
+    tool_started: bool,
+    tool_done: bool,
+}
+
+struct OcState {
+    /// The parent ACP session — a nested spawn's `session.created` (child of
+    /// a child) must not bind to this feed's chips.
+    session_id: String,
+    event_tx: mpsc::Sender<Result<AgentEvent, HarnessError>>,
+    pending: VecDeque<PendingSpawn>,
+    /// child session id → streaming state.
+    children: HashMap<String, ChildState>,
+    unbound: HashMap<String, UnboundChild>,
+    /// Tracker dropped: the bus task exits and late completions settle
+    /// nothing further.
+    torn_down: bool,
+}
+
+pub(crate) struct OpencodeTracker {
+    state: Arc<Mutex<OcState>>,
+}
+
+impl OpencodeTracker {
+    /// `sidecar_base` is the process's HTTP root (`http://127.0.0.1:{port}`);
+    /// `None` (the port pick failed) degrades to chip + final output.
+    pub(crate) fn new(
+        session_id: String,
+        event_tx: mpsc::Sender<Result<AgentEvent, HarnessError>>,
+        sidecar_base: Option<String>,
+    ) -> Self {
+        let state = Arc::new(Mutex::new(OcState {
+            session_id,
+            event_tx,
+            pending: VecDeque::new(),
+            children: HashMap::new(),
+            unbound: HashMap::new(),
+            torn_down: false,
+        }));
+        if let Some(base) = sidecar_base {
+            tokio::spawn(bus_task(Arc::clone(&state), base));
+        }
+        Self { state }
+    }
+
+    /// Inspect one `session/update` payload's `update` object (ACP side).
+    pub(crate) fn observe(&mut self, update: &Value) {
+        if !matches!(
+            update.get("sessionUpdate").and_then(Value::as_str),
+            Some("tool_call") | Some("tool_call_update")
+        ) {
+            return;
+        }
+        let id = update
+            .get("toolCallId")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if id.is_empty() {
+            return;
+        }
+        let mut state = self.state.lock().expect("tracker lock");
+        // A task spawn is identified by its rawInput shape — the tool name is
+        // only ever a display title on this wire. The first `pending` frame
+        // carries an empty rawInput and is skipped; the in_progress update
+        // (full rawInput) lands before the tool runs, so the chip is always
+        // registered ahead of the child's `session.created`.
+        if let Some(raw) = update.get("rawInput")
+            && raw.get("subagent_type").is_some()
+            && raw.get("prompt").is_some()
+        {
+            let description = raw
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let known = state.pending.iter().any(|p| p.tool_call_id == id)
+                || state.children.values().any(|c| c.parent_tool_use_id == id);
+            if !known {
+                state.pending.push_back(PendingSpawn {
+                    tool_call_id: id.to_owned(),
+                    description: description.to_owned(),
+                });
+                // A child that raced ahead of its chip binds now.
+                if let Some(child_id) = match_unbound(&state.unbound, description) {
+                    state.unbound.remove(&child_id);
+                    bind(&mut state, &child_id);
+                }
+            }
+        }
+        let status = update.get("status").and_then(Value::as_str);
+        if matches!(status, Some("completed") | Some("failed")) {
+            self.settle_from_completion(&mut state, id, update, status == Some("failed"));
+        }
+    }
+
+    /// A task chip completed on the ACP wire: bind by the completion's
+    /// authoritative child session id, then settle the chip with a tagged
+    /// Done — after a short drain when the bus streamed (its last frames ride
+    /// an independent channel), immediately with the `<task_result>` fallback
+    /// text when it never did.
+    fn settle_from_completion(
+        &self,
+        state: &mut OcState,
+        tool_call_id: &str,
+        update: &Value,
+        failed: bool,
+    ) {
+        let known_chip = state.pending.iter().any(|p| p.tool_call_id == tool_call_id)
+            || state
+                .children
+                .values()
+                .any(|c| c.parent_tool_use_id == tool_call_id);
+        if !known_chip {
+            return;
+        }
+        let child_id = completion_child_session(update);
+        state.pending.retain(|p| p.tool_call_id != tool_call_id);
+        let child_id = match child_id {
+            Some(id) => {
+                state.unbound.remove(&id);
+                let entry = state.children.entry(id.clone()).or_default();
+                entry.parent_tool_use_id = tool_call_id.to_owned();
+                id
+            }
+            // No id on the completion (older wire?): settle whichever bound
+            // child streams to this chip, else a synthetic record.
+            None => state
+                .children
+                .iter()
+                .find(|(_, c)| c.parent_tool_use_id == tool_call_id)
+                .map(|(id, _)| id.clone())
+                .unwrap_or_else(|| format!("unbound:{tool_call_id}")),
+        };
+        let child = state
+            .children
+            .entry(child_id)
+            .or_insert_with(|| ChildState {
+                parent_tool_use_id: tool_call_id.to_owned(),
+                ..ChildState::default()
+            });
+        if child.done {
+            return;
+        }
+        child.done = true;
+        let status = if failed {
+            DoneStatus::Errored
+        } else {
+            DoneStatus::Completed
+        };
+        let fallback = (!child.saw_transcript)
+            .then(|| completion_result_text(update))
+            .flatten();
+        let parent = child.parent_tool_use_id.clone();
+        let drain = child.saw_transcript;
+        let event_tx = state.event_tx.clone();
+        tokio::spawn(async move {
+            if drain {
+                tokio::time::sleep(SETTLE_DRAIN).await;
+            }
+            if let Some(text) = fallback {
+                let _ = event_tx
+                    .send(Ok(tag(&parent, AgentEvent::TextDelta { text })))
+                    .await;
+            }
+            let _ = event_tx.send(Ok(tag(&parent, done(status)))).await;
+        });
+    }
+}
+
+impl Drop for OpencodeTracker {
+    /// Session teardown with subagents still streaming: settle every open
+    /// chip as interrupted rather than leaving it spinning forever. The
+    /// sends ride spawned tasks (whose `event_tx` clones keep the run's
+    /// event stream open until they land, grok-tail parity).
+    fn drop(&mut self) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        state.torn_down = true;
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let sender = state.event_tx.clone();
+        for child in state.children.values_mut() {
+            if child.done {
+                continue;
+            }
+            child.done = true;
+            let parent = child.parent_tool_use_id.clone();
+            let event_tx = sender.clone();
+            handle.spawn(async move {
+                let _ = event_tx
+                    .send(Ok(tag(&parent, done(DoneStatus::Interrupted))))
+                    .await;
+            });
+        }
+    }
+}
+
+/// The completion's child session id: first-class
+/// `rawOutput.metadata.sessionId`, else parsed from the output's
+/// `<task id="...">` wrapper.
+fn completion_child_session(update: &Value) -> Option<String> {
+    let metadata = update.get("rawOutput").and_then(|r| r.get("metadata"));
+    if let Some(id) = metadata
+        .and_then(|m| m.get("sessionId"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+    {
+        return Some(id.to_owned());
+    }
+    let text = completion_output(update)?;
+    let after = text.split("<task id=\"").nth(1)?;
+    let id = after.split('"').next()?;
+    (!id.is_empty()).then(|| id.to_owned())
+}
+
+/// The completion's raw output text (`rawOutput.output`, else the content
+/// blocks).
+fn completion_output(update: &Value) -> Option<String> {
+    if let Some(text) = update
+        .get("rawOutput")
+        .and_then(|r| r.get("output"))
+        .and_then(Value::as_str)
+    {
+        return Some(text.to_owned());
+    }
+    let parts: Vec<&str> = update
+        .get("content")?
+        .as_array()?
+        .iter()
+        .filter_map(|c| {
+            let block = c.get("content")?;
+            (block.get("type").and_then(Value::as_str) == Some("text"))
+                .then(|| block.get("text").and_then(Value::as_str))
+                .flatten()
+        })
+        .collect();
+    (!parts.is_empty()).then(|| parts.join("\n"))
+}
+
+/// The `<task_result>` body of a completion's output — the whole text when
+/// the wrapper is missing (fail soft on a vendor-private shape).
+fn completion_result_text(update: &Value) -> Option<String> {
+    let text = completion_output(update)?;
+    let body = text
+        .split("<task_result>")
+        .nth(1)
+        .and_then(|t| t.split("</task_result>").next())
+        .unwrap_or(&text)
+        .trim();
+    (!body.is_empty()).then(|| cap_text(body, OUTPUT_CAP))
+}
+
+/// The unbound child whose title matches a pending description, else the
+/// only one (FIFO would need arrival order; one entry is the common case).
+fn match_unbound(unbound: &HashMap<String, UnboundChild>, description: &str) -> Option<String> {
+    if !description.is_empty()
+        && let Some(id) = unbound
+            .iter()
+            .find(|(_, u)| u.title.starts_with(description))
+            .map(|(id, _)| id.clone())
+    {
+        return Some(id);
+    }
+    (unbound.len() == 1)
+        .then(|| unbound.keys().next().cloned())
+        .flatten()
+}
+
+/// Bind a stashed/incoming child to a pending chip: description match
+/// against the child title (`"{description} (@{agent} subagent)"`, FIFO
+/// across identical descriptions), else the oldest pending spawn.
+fn bind_to_pending(state: &mut OcState, child_id: &str, title: &str) -> bool {
+    let ix = state
+        .pending
+        .iter()
+        .position(|p| !p.description.is_empty() && title.starts_with(&p.description))
+        .or(if state.pending.is_empty() {
+            None
+        } else {
+            Some(0)
+        });
+    match ix.and_then(|i| state.pending.remove(i)) {
+        Some(p) => {
+            state.children.insert(
+                child_id.to_owned(),
+                ChildState {
+                    parent_tool_use_id: p.tool_call_id,
+                    ..ChildState::default()
+                },
+            );
+            true
+        }
+        None => false,
+    }
+}
+
+/// Bind a previously-stashed unbound child (title already consumed).
+fn bind(state: &mut OcState, child_id: &str) {
+    if let Some(p) = state.pending.pop_front() {
+        state.children.insert(
+            child_id.to_owned(),
+            ChildState {
+                parent_tool_use_id: p.tool_call_id,
+                ..ChildState::default()
+            },
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bus (SSE) side
+// ---------------------------------------------------------------------------
+
+/// Tail the sidecar's `/event` SSE bus into tagged events. Retries the first
+/// connect (the server binds a few seconds into the process's life); an
+/// established stream ending means the process is exiting — no reconnect,
+/// the ACP completion fallback still settles every chip.
+async fn bus_task(state: Arc<Mutex<OcState>>, base: String) {
+    let Ok(client) = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(2))
+        .build()
+    else {
+        return;
+    };
+    let url = format!("{base}/event");
+    for _ in 0..CONNECT_ATTEMPTS {
+        tokio::time::sleep(CONNECT_POLL).await;
+        if closed(&state) {
+            return;
+        }
+        let Ok(resp) = client.get(&url).send().await else {
+            continue;
+        };
+        if !resp.status().is_success() {
+            continue;
+        }
+        stream_events(&state, resp).await;
+        return;
+    }
+    tracing::debug!(
+        target: "zeron_harness::acp",
+        "opencode sidecar bus never connected ({base}); subagent transcripts degrade to final output"
+    );
+}
+
+async fn stream_events(state: &Arc<Mutex<OcState>>, resp: reqwest::Response) {
+    use futures::StreamExt as _;
+    let mut stream = resp.bytes_stream();
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let Ok(bytes) = chunk else {
+            return;
+        };
+        buf.extend_from_slice(&bytes);
+        // SSE frames are blank-line separated; each data line is one event.
+        while let Some(pos) = find_frame_end(&buf) {
+            let frame: Vec<u8> = buf.drain(..pos + 2).collect();
+            let Ok(frame) = std::str::from_utf8(&frame) else {
+                continue;
+            };
+            for line in frame.lines() {
+                let Some(data) = line
+                    .strip_prefix("data: ")
+                    .or_else(|| line.strip_prefix("data:"))
+                else {
+                    continue;
+                };
+                let Ok(event) = serde_json::from_str::<Value>(data) else {
+                    continue;
+                };
+                let (event_tx, tagged) = {
+                    let Ok(mut state) = state.lock() else {
+                        return;
+                    };
+                    if state.torn_down {
+                        return;
+                    }
+                    (state.event_tx.clone(), handle_bus_event(&mut state, &event))
+                };
+                for ev in tagged {
+                    if event_tx.send(Ok(ev)).await.is_err() {
+                        return;
+                    }
+                }
+            }
+        }
+        if closed(state) {
+            return;
+        }
+    }
+}
+
+fn find_frame_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(2).position(|w| w == b"\n\n")
+}
+
+fn closed(state: &Arc<Mutex<OcState>>) -> bool {
+    state
+        .lock()
+        .map(|s| s.torn_down || s.event_tx.is_closed())
+        .unwrap_or(true)
+}
+
+/// Map one bus event to tagged transcript events (pure bookkeeping +
+/// mapping; the caller sends outside the lock).
+fn handle_bus_event(state: &mut OcState, event: &Value) -> Vec<AgentEvent> {
+    let props = event.get("properties").unwrap_or(&Value::Null);
+    match event.get("type").and_then(Value::as_str) {
+        Some("session.created") => {
+            let info = props.get("info").unwrap_or(&Value::Null);
+            // A nested spawn (a subagent's own subagent) carries the CHILD's
+            // session as parentID — never bind it to this feed's chips.
+            if info.get("parentID").and_then(Value::as_str) != Some(state.session_id.as_str()) {
+                return Vec::new();
+            }
+            let Some(child_id) = info
+                .get("id")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+            else {
+                return Vec::new();
+            };
+            if state.children.contains_key(child_id) {
+                return Vec::new();
+            }
+            let title = info
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if !bind_to_pending(state, child_id, title) {
+                state.unbound.insert(
+                    child_id.to_owned(),
+                    UnboundChild {
+                        title: title.to_owned(),
+                    },
+                );
+            }
+            Vec::new()
+        }
+        Some("message.updated") => {
+            let info = props.get("info").unwrap_or(&Value::Null);
+            let (Some(session), Some(message), Some(role)) = (
+                info.get("sessionID").and_then(Value::as_str),
+                info.get("id").and_then(Value::as_str),
+                info.get("role").and_then(Value::as_str),
+            ) else {
+                return Vec::new();
+            };
+            if let Some(child) = state.children.get_mut(session) {
+                child
+                    .assistant_messages
+                    .entry(message.to_owned())
+                    .or_insert(role == "assistant");
+            }
+            Vec::new()
+        }
+        Some("message.part.updated") => {
+            let part = props.get("part").unwrap_or(&Value::Null);
+            let Some(session) = part.get("sessionID").and_then(Value::as_str) else {
+                return Vec::new();
+            };
+            let Some(child) = state.children.get_mut(session) else {
+                return Vec::new();
+            };
+            let parent = child.parent_tool_use_id.clone();
+            part_snapshot_events(child, part)
+                .into_iter()
+                .map(|ev| tag(&parent, ev))
+                .collect()
+        }
+        Some("message.part.delta") => {
+            let (Some(session), Some(part_id), Some(delta)) = (
+                props.get("sessionID").and_then(Value::as_str),
+                props.get("partID").and_then(Value::as_str),
+                props.get("delta").and_then(Value::as_str),
+            ) else {
+                return Vec::new();
+            };
+            if props.get("field").and_then(Value::as_str) != Some("text") {
+                return Vec::new();
+            }
+            let Some(child) = state.children.get_mut(session) else {
+                return Vec::new();
+            };
+            let parent = child.parent_tool_use_id.clone();
+            part_delta_events(child, props, part_id, delta)
+                .into_iter()
+                .map(|ev| tag(&parent, ev))
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// A part snapshot: emit whatever text extends what already streamed, open /
+/// resolve tool chips. Snapshots and deltas interleave — `emitted` (bytes of
+/// part text already sent) is the dedup line between them.
+fn part_snapshot_events(child: &mut ChildState, part: &Value) -> Vec<AgentEvent> {
+    if child.done {
+        return Vec::new();
+    }
+    let Some(part_id) = part.get("id").and_then(Value::as_str) else {
+        return Vec::new();
+    };
+    let message_id = part
+        .get("messageID")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let kind = part.get("type").and_then(Value::as_str).unwrap_or_default();
+    match kind {
+        "text" | "reasoning" => {
+            // The child's own prompt arrives as a user-message text part.
+            if child.assistant_messages.get(message_id) != Some(&true) {
+                return Vec::new();
+            }
+            let text = part.get("text").and_then(Value::as_str).unwrap_or_default();
+            let entry = child
+                .parts
+                .entry(part_id.to_owned())
+                .or_insert_with(|| PartState {
+                    kind: kind.to_owned(),
+                    ..PartState::default()
+                });
+            let Some(suffix) = text
+                .get(entry.emitted..)
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned)
+            else {
+                // Shorter (or mid-char) snapshot: a rewrite this tracker
+                // doesn't model — drop it rather than duplicate text.
+                return Vec::new();
+            };
+            entry.emitted = text.len();
+            child.saw_transcript = true;
+            vec![if entry.kind == "reasoning" {
+                AgentEvent::ReasoningDelta { text: suffix }
+            } else {
+                AgentEvent::TextDelta { text: suffix }
+            }]
+        }
+        "tool" => {
+            let tool = part.get("tool").and_then(Value::as_str).unwrap_or_default();
+            let status = part
+                .get("state")
+                .and_then(|s| s.get("status"))
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let input = part
+                .get("state")
+                .and_then(|s| s.get("input"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            let call_id = part
+                .get("callID")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .unwrap_or(part_id)
+                .to_owned();
+            let entry = child
+                .parts
+                .entry(part_id.to_owned())
+                .or_insert_with(|| PartState {
+                    kind: "tool".to_owned(),
+                    ..PartState::default()
+                });
+            let mut events = Vec::new();
+            let has_input = input.as_object().is_some_and(|o| !o.is_empty());
+            if !entry.tool_started && (has_input || matches!(status, "completed" | "error")) {
+                entry.tool_started = true;
+                child.saw_transcript = true;
+                events.push(AgentEvent::ToolCall {
+                    id: call_id.clone(),
+                    call: oc_tool_call(tool, &input),
+                });
+            }
+            if entry.tool_started && !entry.tool_done && matches!(status, "completed" | "error") {
+                entry.tool_done = true;
+                let output = part
+                    .get("state")
+                    .and_then(|s| {
+                        s.get("output")
+                            .or_else(|| s.get("error"))
+                            .and_then(Value::as_str)
+                    })
+                    .filter(|t| !t.is_empty())
+                    .map(|t| cap_text(t, OUTPUT_CAP));
+                events.push(AgentEvent::ToolResult {
+                    id: call_id,
+                    is_error: status == "error",
+                    output,
+                    diff: None,
+                });
+            }
+            events
+        }
+        // step-start / step-finish / snapshot bookkeeping: not transcript.
+        _ => Vec::new(),
+    }
+}
+
+/// A text delta appends to its part. Deltas follow the part's opening
+/// `message.part.updated` (which fixes the kind); an unknown part defaults
+/// to assistant text only when its message is known assistant.
+fn part_delta_events(
+    child: &mut ChildState,
+    props: &Value,
+    part_id: &str,
+    delta: &str,
+) -> Vec<AgentEvent> {
+    if child.done || delta.is_empty() {
+        return Vec::new();
+    }
+    let message_id = props
+        .get("messageID")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if child.assistant_messages.get(message_id) != Some(&true) {
+        return Vec::new();
+    }
+    let entry = child
+        .parts
+        .entry(part_id.to_owned())
+        .or_insert_with(|| PartState {
+            kind: "text".to_owned(),
+            ..PartState::default()
+        });
+    if entry.kind == "tool" {
+        return Vec::new();
+    }
+    entry.emitted += delta.len();
+    child.saw_transcript = true;
+    vec![if entry.kind == "reasoning" {
+        AgentEvent::ReasoningDelta {
+            text: delta.to_owned(),
+        }
+    } else {
+        AgentEvent::TextDelta {
+            text: delta.to_owned(),
+        }
+    }]
+}
+
+/// Type an opencode-native tool invocation (bus names, not ACP kinds).
+fn oc_tool_call(name: &str, input: &Value) -> ToolCall {
+    let s = |keys: &[&str]| {
+        keys.iter()
+            .find_map(|k| input.get(*k))
+            .and_then(Value::as_str)
+            .filter(|v| !v.is_empty())
+            .map(str::to_owned)
+    };
+    match name {
+        "bash" => ToolCall::Exec {
+            command: s(&["command"]).unwrap_or_default(),
+        },
+        "read" => ToolCall::ReadFile {
+            path: s(&["filePath", "file_path", "path"]).unwrap_or_default(),
+        },
+        "write" => ToolCall::WriteFile {
+            path: s(&["filePath", "file_path", "path"]).unwrap_or_default(),
+            content: s(&["content"]),
+        },
+        "edit" => ToolCall::EditFile {
+            path: s(&["filePath", "file_path", "path"]).unwrap_or_default(),
+            old_string: s(&["oldString", "old_string"]),
+            new_string: s(&["newString", "new_string"]),
+        },
+        "patch" => ToolCall::ApplyPatch {
+            path: s(&["filePath", "file_path", "path"]),
+        },
+        "grep" => ToolCall::Search {
+            pattern: s(&["pattern"]).unwrap_or_default(),
+            path: s(&["path", "include"]),
+        },
+        "glob" => ToolCall::Glob {
+            pattern: s(&["pattern"]).unwrap_or_default(),
+        },
+        "webfetch" => ToolCall::WebFetch {
+            url: s(&["url"]).unwrap_or_default(),
+            prompt: None,
+        },
+        "websearch" => ToolCall::WebSearch {
+            query: s(&["query"]).unwrap_or_default(),
+        },
+        "todowrite" => ToolCall::Todo {
+            items: input
+                .get("todos")
+                .and_then(Value::as_array)
+                .map(|a| a.as_slice())
+                .unwrap_or_default()
+                .iter()
+                .map(|t| TodoItem {
+                    text: t
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_owned(),
+                    done: t.get("status").and_then(Value::as_str) == Some("completed"),
+                })
+                .collect(),
+        },
+        // A nested spawn inside the subagent: same naming as the parent chip
+        // (no recursive viz — it renders as a plain chip in the child doc).
+        "task" => ToolCall::Unknown {
+            name: s(&["description"])
+                .map(|d| format!("Agent: {d}"))
+                .unwrap_or_else(|| "Agent".into()),
+            input: (!input.is_null()).then(|| input.clone()),
+        },
+        _ => ToolCall::Unknown {
+            name: name.to_owned(),
+            input: (!input.is_null()).then(|| input.clone()),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn tracker() -> (
+        OpencodeTracker,
+        mpsc::Receiver<Result<AgentEvent, HarnessError>>,
+    ) {
+        let (tx, rx) = mpsc::channel(64);
+        (OpencodeTracker::new("ses_parent".into(), tx, None), rx)
+    }
+
+    fn task_update(id: &str, status: &str, raw_output: Option<Value>) -> Value {
+        let mut update = json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": id,
+            "status": status,
+            "kind": "think",
+            "title": "Viz probe",
+            "rawInput": {
+                "description": "Viz probe",
+                "prompt": "run the probe",
+                "subagent_type": "general",
+            },
+        });
+        if let Some(raw) = raw_output {
+            update["rawOutput"] = raw;
+        }
+        update
+    }
+
+    #[test]
+    fn completion_metadata_yields_the_child_session() {
+        let update = task_update(
+            "t1",
+            "completed",
+            Some(json!({
+                "output": "<task id=\"ses_child\" state=\"completed\">\n<task_result>\nfinished\n</task_result>\n</task>",
+                "metadata": {"parentSessionId": "ses_parent", "sessionId": "ses_child"},
+            })),
+        );
+        assert_eq!(
+            completion_child_session(&update).as_deref(),
+            Some("ses_child")
+        );
+        assert_eq!(completion_result_text(&update).as_deref(), Some("finished"));
+        // metadata absent → the <task id> wrapper still yields the id.
+        let update = task_update(
+            "t1",
+            "completed",
+            Some(json!({
+                "output": "<task id=\"ses_x\" state=\"completed\">\n<task_result>\nok\n</task_result>\n</task>",
+            })),
+        );
+        assert_eq!(completion_child_session(&update).as_deref(), Some("ses_x"));
+    }
+
+    #[tokio::test]
+    async fn unstreamed_child_settles_with_fallback_text_and_done() {
+        let (mut tracker, mut rx) = tracker();
+        tracker.observe(&task_update("t1", "in_progress", None));
+        tracker.observe(&task_update(
+            "t1",
+            "completed",
+            Some(json!({
+                "output": "<task id=\"ses_child\" state=\"completed\">\n<task_result>\nfinished\n</task_result>\n</task>",
+                "metadata": {"sessionId": "ses_child"},
+            })),
+        ));
+        let ev = rx.recv().await.expect("event").expect("ok");
+        assert!(matches!(
+            &ev,
+            AgentEvent::Subagent { parent_tool_use_id, event }
+                if parent_tool_use_id == "t1"
+                    && matches!(&**event, AgentEvent::TextDelta { text } if text == "finished")
+        ));
+        let ev = rx.recv().await.expect("event").expect("ok");
+        assert!(matches!(
+            &ev,
+            AgentEvent::Subagent { event, .. }
+                if matches!(&**event, AgentEvent::Done { status: DoneStatus::Completed, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn bus_traffic_streams_tagged_and_completion_settles() {
+        let (mut tracker, mut rx) = tracker();
+        tracker.observe(&task_update("t1", "in_progress", None));
+        {
+            let mut state = tracker.state.lock().unwrap();
+            // Real 1.18.18 bus shapes.
+            let created = json!({"type": "session.created", "properties": {"info": {
+                "id": "ses_child", "parentID": "ses_parent",
+                "title": "Viz probe (@general subagent)", "agent": "general",
+            }}});
+            assert!(handle_bus_event(&mut state, &created).is_empty());
+            assert!(state.children.contains_key("ses_child"));
+
+            let user_msg = json!({"type": "message.updated", "properties": {"info": {
+                "id": "msg_u", "role": "user", "sessionID": "ses_child",
+            }}});
+            handle_bus_event(&mut state, &user_msg);
+            let user_part = json!({"type": "message.part.updated", "properties": {"part": {
+                "id": "prt_u", "messageID": "msg_u", "sessionID": "ses_child",
+                "type": "text", "text": "run the probe",
+            }}});
+            assert!(handle_bus_event(&mut state, &user_part).is_empty());
+
+            let asst_msg = json!({"type": "message.updated", "properties": {"info": {
+                "id": "msg_a", "role": "assistant", "sessionID": "ses_child",
+            }}});
+            handle_bus_event(&mut state, &asst_msg);
+            let tool_running = json!({"type": "message.part.updated", "properties": {"part": {
+                "id": "prt_t", "messageID": "msg_a", "sessionID": "ses_child",
+                "type": "tool", "tool": "bash", "callID": "call-1",
+                "state": {"status": "running", "input": {"command": "echo ok"}},
+            }}});
+            let events = handle_bus_event(&mut state, &tool_running);
+            assert!(matches!(
+                events.as_slice(),
+                [AgentEvent::Subagent { parent_tool_use_id, event }]
+                    if parent_tool_use_id == "t1"
+                        && matches!(&**event, AgentEvent::ToolCall { id, call: ToolCall::Exec { command } }
+                            if id == "call-1" && command == "echo ok")
+            ));
+            // Repeated running snapshots don't re-open the chip.
+            assert!(handle_bus_event(&mut state, &tool_running).is_empty());
+            let tool_done = json!({"type": "message.part.updated", "properties": {"part": {
+                "id": "prt_t", "messageID": "msg_a", "sessionID": "ses_child",
+                "type": "tool", "tool": "bash", "callID": "call-1",
+                "state": {"status": "completed", "input": {"command": "echo ok"}, "output": "ok\n"},
+            }}});
+            let events = handle_bus_event(&mut state, &tool_done);
+            assert!(matches!(
+                events.as_slice(),
+                [AgentEvent::Subagent { event, .. }]
+                    if matches!(&**event, AgentEvent::ToolResult { id, is_error: false, output: Some(o), .. }
+                        if id == "call-1" && o == "ok\n")
+            ));
+
+            // Snapshot + delta interleave dedups by emitted length.
+            let text_open = json!({"type": "message.part.updated", "properties": {"part": {
+                "id": "prt_x", "messageID": "msg_a", "sessionID": "ses_child",
+                "type": "text", "text": "",
+            }}});
+            assert!(handle_bus_event(&mut state, &text_open).is_empty());
+            let delta = json!({"type": "message.part.delta", "properties": {
+                "sessionID": "ses_child", "messageID": "msg_a", "partID": "prt_x",
+                "field": "text", "delta": "finished ",
+            }});
+            let events = handle_bus_event(&mut state, &delta);
+            assert!(matches!(
+                events.as_slice(),
+                [AgentEvent::Subagent { event, .. }]
+                    if matches!(&**event, AgentEvent::TextDelta { text } if text == "finished ")
+            ));
+            let settled = json!({"type": "message.part.updated", "properties": {"part": {
+                "id": "prt_x", "messageID": "msg_a", "sessionID": "ses_child",
+                "type": "text", "text": "finished ",
+            }}});
+            assert!(handle_bus_event(&mut state, &settled).is_empty());
+        }
+        // The ACP completion settles the chip: drain, then tagged Done (no
+        // fallback text — the transcript already streamed).
+        tracker.observe(&task_update(
+            "t1",
+            "completed",
+            Some(json!({
+                "output": "<task id=\"ses_child\" state=\"completed\">\n<task_result>\nfinished\n</task_result>\n</task>",
+                "metadata": {"sessionId": "ses_child"},
+            })),
+        ));
+        let ev = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("settles")
+            .expect("event")
+            .expect("ok");
+        assert!(matches!(
+            &ev,
+            AgentEvent::Subagent { parent_tool_use_id, event }
+                if parent_tool_use_id == "t1"
+                    && matches!(&**event, AgentEvent::Done { status: DoneStatus::Completed, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn nested_children_and_foreign_sessions_never_bind() {
+        let (mut tracker, _rx) = tracker();
+        tracker.observe(&task_update("t1", "in_progress", None));
+        let mut state = tracker.state.lock().unwrap();
+        let nested = json!({"type": "session.created", "properties": {"info": {
+            "id": "ses_grandchild", "parentID": "ses_child",
+            "title": "Nested (@general subagent)",
+        }}});
+        handle_bus_event(&mut state, &nested);
+        assert!(state.children.is_empty());
+        assert_eq!(state.pending.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn teardown_settles_open_chips_interrupted() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let tracker = OpencodeTracker::new("ses_parent".into(), tx, None);
+        {
+            let mut state = tracker.state.lock().unwrap();
+            state.children.insert(
+                "ses_child".into(),
+                ChildState {
+                    parent_tool_use_id: "t1".into(),
+                    saw_transcript: true,
+                    ..ChildState::default()
+                },
+            );
+        }
+        drop(tracker);
+        let ev = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("settles")
+            .expect("event")
+            .expect("ok");
+        assert!(matches!(
+            &ev,
+            AgentEvent::Subagent { parent_tool_use_id, event }
+                if parent_tool_use_id == "t1"
+                    && matches!(&**event, AgentEvent::Done { status: DoneStatus::Interrupted, .. })
+        ));
+    }
+
+    #[test]
+    fn tool_names_type_the_common_calls() {
+        let call = oc_tool_call("bash", &json!({"command": "ls -la", "description": "list"}));
+        assert_eq!(
+            call,
+            ToolCall::Exec {
+                command: "ls -la".into()
+            }
+        );
+        let call = oc_tool_call("read", &json!({"filePath": "/w/a.rs"}));
+        assert_eq!(
+            call,
+            ToolCall::ReadFile {
+                path: "/w/a.rs".into()
+            }
+        );
+        let call = oc_tool_call(
+            "edit",
+            &json!({"filePath": "/w/a.rs", "oldString": "a", "newString": "b"}),
+        );
+        assert_eq!(
+            call,
+            ToolCall::EditFile {
+                path: "/w/a.rs".into(),
+                old_string: Some("a".into()),
+                new_string: Some("b".into()),
+            }
+        );
+        let call = oc_tool_call("task", &json!({"description": "Scan crates"}));
+        assert!(matches!(call, ToolCall::Unknown { name, .. } if name == "Agent: Scan crates"));
+        let call = oc_tool_call("mystery", &json!({"x": 1}));
+        assert!(matches!(call, ToolCall::Unknown { name, input: Some(_) } if name == "mystery"));
+    }
+}

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -4,10 +4,11 @@
 //! stream-json ([`ClaudeHarness`]), Codex over the app-server JSON-RPC
 //! ([`CodexHarness`]), Cursor through a pinned @cursor/sdk shim
 //! ([`CursorHarness`]). The shared [`AcpHarness`] remains ONLY for agents
-//! built ground-up on ACP — Grok (`grok agent stdio`) and Hermes
-//! (`hermes acp`) — plus pi via the community `pi-acp` adapter until a
-//! native driver exists. Adapter-mediated ACP for claude/codex/cursor was
-//! retired: the adapters held prompt turns open for background work the
+//! built ground-up on ACP — Grok (`grok agent stdio`), Hermes
+//! (`hermes acp`) and opencode (`opencode acp`) — plus pi via the community
+//! `pi-acp` adapter until a native driver exists. Adapter-mediated ACP for
+//! claude/codex/cursor was retired: the
+//! adapters held prompt turns open for background work the
 //! CLIs themselves settle eagerly, manufacturing done-status bugs the
 //! native wires don't have (decision record: docs/research/acp.md).
 

--- a/crates/harness/tests/acp.rs
+++ b/crates/harness/tests/acp.rs
@@ -7,9 +7,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use tokio::sync::{mpsc, oneshot};
 
-use zeron_harness::{
-    AcpHarness, CancellationToken, Harness, RunControls, SteerMessage,
-};
+use zeron_harness::{AcpHarness, CancellationToken, Harness, RunControls, SteerMessage};
 use zeron_proto::{
     AgentEvent, DoneStatus, HarnessId, RunRequest, SandboxLevel, SteeringMode, TodoItem, ToolCall,
     UserInputAnswer,
@@ -575,6 +573,13 @@ fn hermes_and_pi_descriptor_surfaces_match_registry_expectations() {
     assert_eq!(hermes.steering_mode(), SteeringMode::TurnBoundary);
     assert!(hermes.reasoning_levels().is_empty());
 
+    let opencode = AcpHarness::opencode();
+    assert_eq!(opencode.id(), HarnessId::Opencode);
+    assert_eq!(opencode.display_name(), "OpenCode");
+    assert!(opencode.supports_steering());
+    assert_eq!(opencode.steering_mode(), SteeringMode::TurnBoundary);
+    assert!(opencode.reasoning_levels().is_empty());
+
     let pi = AcpHarness::pi();
     assert_eq!(pi.id(), HarnessId::Pi);
     assert_eq!(pi.display_name(), "Pi");
@@ -764,8 +769,9 @@ async fn grok_subagent_lifecycle_tails_the_disk_transcript_into_tagged_events() 
         )
     })
     .expect("tool result tailed");
-    let text = pos(&|e| matches!(e, AgentEvent::TextDelta { text } if text.starts_with("two files")))
-        .expect("mid-run append tailed");
+    let text =
+        pos(&|e| matches!(e, AgentEvent::TextDelta { text } if text.starts_with("two files")))
+            .expect("mid-run append tailed");
     let done = pos(&|e| {
         matches!(
             e,

--- a/crates/harness/tests/real_quiet_survey.rs
+++ b/crates/harness/tests/real_quiet_survey.rs
@@ -202,6 +202,7 @@ async fn real_all_harnesses_quiet_survey() {
         ("grok", AcpHarness::grok),
         ("hermes", AcpHarness::hermes),
         ("pi", AcpHarness::pi),
+        ("opencode", AcpHarness::opencode),
     ];
     let mut failures: Vec<String> = Vec::new();
     for (name, ctor) in agents {

--- a/crates/proto/src/agent.rs
+++ b/crates/proto/src/agent.rs
@@ -14,6 +14,8 @@ pub enum HarnessId {
     Hermes,
     /// The pi coding agent (pi.dev), driven over ACP via the `pi-acp` adapter.
     Pi,
+    /// SST's opencode agent, driven over ACP (`opencode acp`).
+    Opencode,
     /// Test harness; never shown in production pickers.
     Mock,
 }

--- a/crates/ui/assets/icons/opencode-mark.svg
+++ b/crates/ui/assets/icons/opencode-mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 30">
+    <path fill="currentColor" fill-rule="evenodd" d="M24 0H0V30H24V0ZM18 6H6V24H18V6Z"/>
+    <path fill="currentColor" fill-opacity="0.45" d="M18 12H6V24H18V12Z"/>
+</svg>

--- a/crates/ui/src/icons.rs
+++ b/crates/ui/src/icons.rs
@@ -148,6 +148,7 @@ icon_assets![
     (GROK_MARK, "grok-mark"),
     (HERMES_MARK, "hermes-mark"),
     (PI_MARK, "pi-mark"),
+    (OPENCODE_MARK, "opencode-mark"),
 ];
 
 /// The Claude mark's brand orange (`#D97757`) — zeron keeps it even on the

--- a/crates/ui/src/pickers.rs
+++ b/crates/ui/src/pickers.rs
@@ -3293,6 +3293,8 @@ pub(crate) fn harness_brand_icon(harness: HarnessId) -> (&'static str, Option<gp
         // Nous Research's mark (the Hermes product icon), monochrome.
         HarnessId::Hermes => (crate::icons::HERMES_MARK, None),
         HarnessId::Pi => (crate::icons::PI_MARK, None),
+        // The pixel-"o" from opencode's wordmark (their favicon), monochrome.
+        HarnessId::Opencode => (crate::icons::OPENCODE_MARK, None),
     }
 }
 

--- a/crates/ui/src/settings/accounts.rs
+++ b/crates/ui/src/settings/accounts.rs
@@ -1212,6 +1212,7 @@ impl Render for AccountsPage {
             HarnessId::Grok => (crate::icons::GROK_MARK, None),
             HarnessId::Hermes => (crate::icons::HERMES_MARK, None),
             HarnessId::Pi => (crate::icons::PI_MARK, None),
+            HarnessId::Opencode => (crate::icons::OPENCODE_MARK, None),
             _ => (
                 crate::icons::CLAUDE_MARK,
                 Some(crate::icons::claude_brand()),

--- a/crates/ui/src/settings/harnesses.rs
+++ b/crates/ui/src/settings/harnesses.rs
@@ -39,6 +39,7 @@ pub fn blurb(harness: HarnessId) -> &'static str {
         HarnessId::Grok => "xAI's Grok Build agent (grok CLI).",
         HarnessId::Hermes => "Nous Research's Hermes Agent (hermes CLI).",
         HarnessId::Pi => "The pi coding agent (pi CLI).",
+        HarnessId::Opencode => "SST's opencode agent (opencode CLI).",
         HarnessId::Mock => "Scripted test harness.",
     }
 }
@@ -52,6 +53,7 @@ pub fn cli_name(harness: HarnessId) -> &'static str {
         HarnessId::Grok => "grok",
         HarnessId::Hermes => "hermes",
         HarnessId::Pi => "pi",
+        HarnessId::Opencode => "opencode",
         HarnessId::Mock => "mock",
     }
 }


### PR DESCRIPTION
Adds **OpenCode** (SST's `opencode`, driven over `opencode acp`) as a harness, with full subagent virtualization (chip + per-subagent doc/tab, PR #136 architecture).

## Harness (new-agent recipe)
- `HarnessId::Opencode` → `AcpAgentSpec` → `registry_lazy` slot → `harness_slug` → mark SVG (the pixel-"o" from opencode's wordmark/favicon, monochrome currentColor) → picker/settings/accounts arms → descriptor tests extended.
- **No npm shim**: the `opencode-ai` npm package ships a native platform binary (`bin/opencode.exe` swapped by postinstall), so the managed `node <entry>` adapter path can't drive it. The CLI itself is the ACP server — install detection mirrors grok/hermes (`~/.opencode/bin`, npm globals, brew paths; `OPENCODE_EXECUTABLE` override).
- Model discovery rides the existing config-option probe — verified live that `session/new` advertises the `model` select (all configured providers + OpenCode Zen frees) with **no auth**. No `thought_level` option exists → empty effort ladder (hermes parity). Turn-boundary steering; `loadSession: true` so resume works.

## Subagent viz — the wire facts (live-validated on 1.18.18)
- The `task` tool call rides the parent's `session/update` (kind `think`, `rawInput {description, prompt, subagent_type}`); its completion carries the child session id first-class in `rawOutput.metadata` (`sessionId` + `parentSessionId`).
- The child's interior transcript **never appears on the ACP wire**, and 1.18 moved session storage to SQLite — no grok-style JSONL tail exists.
- But `opencode acp` always doubles as opencode's HTTP server, and its `/event` SSE bus broadcasts every session's events, children included, token-level. Runs pass `--port <free-port>` (the shared default 4096 loses silently under concurrent binds — verified the loser stays up, ACP-fine, just serverless).

`OpencodeTracker` (`acp/subagent_opencode.rs`): task chips register from the ACP side; the bus's `session.created` (`parentID` = parent session, title `"{description} (@agent subagent)"`) binds children by description else FIFO, with the completion metadata as authoritative late binding; `message.part.updated`/`message.part.delta` map to tagged `AgentEvent::Subagent` traffic (snapshot/delta dedup by emitted length, user-message echoes filtered by role, typed tool chips via opencode's native tool names); the ACP task completion settles the chip with a tagged Done after a short drain. Teardown settles open chips Interrupted (grok-tail parity). Every bus parse fails soft → chip + final `<task_result>` text.

A normalize arm keeps `Agent: {description}` chip naming across the completion frame (it drops `rawInput` but keeps the spawn signature in `rawOutput.metadata` — without this the chip lost its bot icon/label at completion, caught live).

## Validation
- `examples/opencode_subagent_probe.rs` (kept for bump revalidation) against the **real opencode 1.18.18** with a mock OpenAI-compatible provider forcing deterministic spawns:
  - single task: tagged `Exec` → `ToolResult` → `TextDelta` → `Done` attributed to the spawn chip, parent text streams around it;
  - two concurrent tasks: interleaved children stream to the **right** chips (`call-task-A`/`call-task-B`), both keep Agent naming through completion.
- Engine needed zero changes — generic `AgentEvent::Subagent` routing from #136.
- Full workspace suite green except `cursor_slot_swap_round_trip`, which fails under parallel binary load and passes solo (slot-order flake, same class as the known `interrupt_stamps_streaming_entry_aborted` one; unrelated to this change).

## Follow-ups
- No `_session/steering` / `thought_level` on opencode's ACP surface today — revisit on bump.
- Nested spawns render as plain chips in the child doc (no recursive viz, grok parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeronsh/codesmith/comet/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789664426&installation_model_id=425430&pr_number=157&repository=zeronsh%2Fcomet&return_to=https%3A%2F%2Fgithub.com%2Fzeronsh%2Fcomet%2Fpull%2F157&signature=de62e61804c93fd1329a939fc8635f485e2eb4be3780e79ab37494176f64459c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Media (headless rig, dark, mock provider)

**Composer picker — OpenCode in the harness rail with the live-discovered model list (no auth):**

<img src="https://github.com/user-attachments/assets/f5378a0f-5ea3-459d-aeeb-0afc364be842" width="720" />

**Two concurrent subagents streaming (parent Working, both Agent chips bound):**

<img src="https://github.com/user-attachments/assets/573d75fe-7b67-42ea-8d94-e8a3d6c2e791" width="720" />

**Run settled — chips quiet, parent wrap-up:**

<img src="https://github.com/user-attachments/assets/134fad4b-9489-4f94-a9e5-5a3a5bc01405" width="720" />

**Subagent tab open — the child's own transcript (`Run sleep 6 && echo alpha-ok` + reply) beside the parent doc:**

<img src="https://github.com/user-attachments/assets/b611e28b-103f-40c9-9a52-df4549d51bef" width="720" />

**Settings → Agents — OpenCode row, installed + enabled:**

<img src="https://github.com/user-attachments/assets/d726f38c-4cfe-40fb-b970-a03a1fda0ea4" width="720" />
